### PR TITLE
【增加】 配置文件支持指定openai的baseurl和模型名称，可用于本地模型或者openai代理场景

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -47,3 +47,5 @@ WEBHOOK_VERIFY_TOKEN = "asdhiqbryuwfqodwgeayrgfbsifbd"
 gitlab_server_url = gitlab_server_url
 gitlab_private_token = gitlab_private_token
 openai_api_key = openai_api_key
+openai_baseurl = "https://api.openai.com/v1"
+openai_model_name = "gpt-3.5-turbo"

--- a/service/chat_review.py
+++ b/service/chat_review.py
@@ -9,7 +9,7 @@ import requests
 from openai import OpenAIError
 from retrying import retry
 
-from config.config import gitlab_server_url, gitlab_private_token, openai_api_key
+from config.config import gitlab_server_url, gitlab_private_token, openai_api_key, openai_baseurl, openai_model_name
 from service.content_handle import filter_diff_content
 from utils.LogHandler import log
 
@@ -51,6 +51,7 @@ def wait_and_retry(exception):
 def generate_review_note(change):
     content = filter_diff_content(change['diff'])
     openai.api_key = openai_api_key
+    openai.api_base = openai_baseurl
     messages = [
         {"role": "system",
          "content": "你是是一位资深编程专家，gitlab的commit代码变更将以git diff 字符串的形式提供，以格式「变更评分：实际的分数」给变更打分，分数区间为0~100分。输出格式：然后，以精炼的语言、严厉的语气指出存在的问题。如果你觉得必要的情况下，可直接给出修改后的内容。你的反馈内容必须使用严谨的markdown格式。"
@@ -60,7 +61,7 @@ def generate_review_note(change):
          },
     ]
     response = openai.ChatCompletion.create(
-        model="gpt-3.5-turbo",
+        model=openai_model_name,
         messages=messages,
     )
     new_path = change['new_path']


### PR DESCRIPTION
哈喽，南宫大佬，这是PR是在config/config.py中增加两个配置来支持我能想到的一些常见的使用场景，希望也能对项目做出贡献。

新增配置：主要是为了满足使用http代理访问Openai API的场景以及本地部署推理服务进行推理的场景。
openai_baseurl：
- 改动前：默认使用openai官方提供的API地址 “https://api.openai.com/v1“
- 改动后：可以指定不同的url作为请求的目标.该目标可以是http代理的服务地址也可以是本地推理服务提供的服务地址.
openai_model_name:
- 改动前：默认为 “gpt-3.5-turbo“，不可指定
- 改动后：可指定

